### PR TITLE
ci: upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/retrieve-and-host.yml
+++ b/.github/workflows/retrieve-and-host.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Fetch project info & Render badges
       run: |


### PR DESCRIPTION
Upgrade actions/checkout to v4 to suppress "running with node12" warning.

![image](https://github.com/user-attachments/assets/6044b0ae-4347-4bda-86ed-53d452201f6c)
